### PR TITLE
Fix deserialization for methods without annotations

### DIFF
--- a/serde/src/main/scala/com/github/gchudnov/bscript/serde/internal/JSONDeserializeVisitor.scala
+++ b/serde/src/main/scala/com/github/gchudnov/bscript/serde/internal/JSONDeserializeVisitor.scala
@@ -239,7 +239,7 @@ private[internal] final class JSONDeserializeVisitor:
       params   <- Transform.sequence(jParams.arr.map(jEl => visitAST(jEl).flatMap(_.asArgDecl)))
       jBody    <- (s \ Keys.body).asJObject
       body     <- visitAST(jBody).flatMap(_.asBlock)
-      jAnns    <- (s \ Keys.annotations).asJArray
+      jAnns    <- (s \ Keys.annotations).asNullJArray
       anns     <- Transform.sequence(jAnns.arr.map(jEl => visitAnn(jEl)))
     yield MethodDecl(retType, name, params, body, anns)
 
@@ -453,6 +453,15 @@ private[internal] object JSONDeserializeVisitor:
 
     def asJArray: Either[Throwable, JArray] =
       value match
+        case a: JArray =>
+          Right(a)
+        case other =>
+          Left(new SerdeException(s"Cannot convert JValue '${other}' to JArray"))
+
+    def asNullJArray: Either[Throwable, JArray] =
+      value match
+        case JNothing | JNull =>
+          Right(JArray(List.empty[JValue]))
         case a: JArray =>
           Right(a)
         case other =>

--- a/serde/src/main/scala/com/github/gchudnov/bscript/serde/internal/JSONDeserializeVisitor.scala
+++ b/serde/src/main/scala/com/github/gchudnov/bscript/serde/internal/JSONDeserializeVisitor.scala
@@ -349,8 +349,8 @@ private[internal] final class JSONDeserializeVisitor:
     s match
       case JString(s) =>
         Right(SymbolRef(s))
-      case _ =>
-        Left(new SerdeException("Cannot convert JValue to a Symbol"))
+      case other =>
+        Left(new SerdeException(s"Cannot convert JValue '${other}' to a Symbol"))
 
   private def visitType(s: JValue): Either[Throwable, Type] =
     s match
@@ -367,8 +367,8 @@ private[internal] final class JSONDeserializeVisitor:
         yield t
       case JString(value) =>
         Right(TypeRef(value))
-      case _ =>
-        Left(new SerdeException("Cannot extract Type from JValue"))
+      case other =>
+        Left(new SerdeException(s"Cannot extract Type from JValue '${other}'"))
 
   private def visitAnn(s: JValue): Either[Throwable, Ann] =
     s match
@@ -382,8 +382,8 @@ private[internal] final class JSONDeserializeVisitor:
                  case `stdAnnName` =>
                    Right(StdAnn()) // NOTE: the value is not important, since we're not allowing to override it
         yield t
-      case _ =>
-        Left(new SerdeException("Cannot extract Annotation from JValue"))
+      case other =>
+        Left(new SerdeException(s"Cannot extract Annotation from JValue '${other}'"))
 
 private[internal] object JSONDeserializeVisitor:
 
@@ -441,22 +441,22 @@ private[internal] object JSONDeserializeVisitor:
       value match
         case s: JString =>
           Right(s)
-        case _ =>
-          Left(new SerdeException("Cannot convert JValue to JString"))
+        case other =>
+          Left(new SerdeException(s"Cannot convert JValue '${other}' to JString"))
 
     def asJObject: Either[Throwable, JObject] =
       value match
         case o: JObject =>
           Right(o)
-        case _ =>
-          Left(new SerdeException("Cannot convert JValue to JObject"))
+        case other =>
+          Left(new SerdeException(s"Cannot convert JValue '${other}' to JObject"))
 
     def asJArray: Either[Throwable, JArray] =
       value match
         case a: JArray =>
           Right(a)
-        case _ =>
-          Left(new SerdeException("Cannot convert JValue to JArray"))
+        case other =>
+          Left(new SerdeException(s"Cannot convert JValue '${other}' to JArray"))
 
   def parseBool(s: String): Either[Throwable, Boolean] =
     s match
@@ -464,47 +464,47 @@ private[internal] object JSONDeserializeVisitor:
         Right(true)
       case "false" =>
         Right(false)
-      case _ =>
-        Left(new SerdeException("Cannot parse Boolean"))
+      case other =>
+        Left(new SerdeException(s"Cannot parse Boolean from '${other}'"))
 
   def parseInt(s: String): Either[Throwable, Int] =
     allCatch
       .either(s.toInt)
       .left
-      .map(_ => new SerdeException("Cannot parse Int"))
+      .map(t => new SerdeException(s"Cannot parse Int from '${s}'", t))
 
   def parseLong(s: String): Either[Throwable, Long] =
     allCatch
       .either(s.toLong)
       .left
-      .map(_ => new SerdeException("Cannot parse Long"))
+      .map(t => new SerdeException(s"Cannot parse Long from '${s}'", t))
 
   def parseFloat(s: String): Either[Throwable, Float] =
     allCatch
       .either(s.toFloat)
       .left
-      .map(_ => new SerdeException("Cannot parse Float"))
+      .map(t => new SerdeException(s"Cannot parse Float from '${s}'", t))
 
   def parseDouble(s: String): Either[Throwable, Double] =
     allCatch
       .either(s.toDouble)
       .left
-      .map(_ => new SerdeException("Cannot parse Double"))
+      .map(t => new SerdeException(s"Cannot parse Double from '${s}'", t))
 
   def parseDecimal(s: String): Either[Throwable, BigDecimal] =
     allCatch
       .either(BigDecimal(s))
       .left
-      .map(_ => new SerdeException("Cannot parse BigDecimal"))
+      .map(t => new SerdeException(s"Cannot parse BigDecimal from '${s}'", t))
 
   def parseDate(s: String): Either[Throwable, LocalDate] =
     allCatch
       .either(LocalDate.parse(s))
       .left
-      .map(_ => new SerdeException("Cannot parse LocalDate"))
+      .map(t => new SerdeException(s"Cannot parse LocalDate from '${s}'", t))
 
   def parseDateTime(s: String): Either[Throwable, OffsetDateTime] =
     allCatch
       .either(OffsetDateTime.parse(s))
       .left
-      .map(_ => new SerdeException("Cannot parse OffsetDateTime"))
+      .map(t => new SerdeException(s"Cannot parse OffsetDateTime from '${s}'", t))

--- a/serde/src/test/resources/data/ast-example-1.json
+++ b/serde/src/test/resources/data/ast-example-1.json
@@ -1,0 +1,157 @@
+{
+    "kind": "Block",
+    "statements": [
+        {
+            "kind": "StructDecl",
+            "name": "A",
+            "fields": [
+                {
+                    "kind": "FieldDecl",
+                    "type": "int",
+                    "name": "x"
+                },
+                {
+                    "kind": "FieldDecl",
+                    "type": "B",
+                    "name": "b"
+                }
+            ]
+        },
+        {
+            "kind": "StructDecl",
+            "name": "B",
+            "fields": [
+                {
+                    "kind": "FieldDecl",
+                    "type": "int",
+                    "name": "y"
+                }
+            ]
+        },
+        {
+            "kind": "VarDecl",
+            "type": "A",
+            "name": "a",
+            "expr": {
+                "kind": "Init",
+                "type": "A"
+            }
+        },
+        {
+            "kind": "MethodDecl",
+            "retType": "void",
+            "name": "f",
+            "params": [
+                {
+                    "kind": "ArgDecl",
+                    "type": "int",
+                    "name": "x"
+                }
+            ],
+            "body": {
+                "kind": "Block",
+                "statements": [
+                    {
+                        "kind": "Assign",
+                        "id": {
+                            "kind": "Access",
+                            "a": {
+                                "kind": "Access",
+                                "a": {
+                                    "kind": "Var",
+                                    "symbol": "a"
+                                },
+                                "b": {
+                                    "kind": "Var",
+                                    "symbol": "b"
+                                }
+                            },
+                            "b": {
+                                "kind": "Var",
+                                "symbol": "y"
+                            }
+                        },
+                        "expr": {
+                            "kind": "Var",
+                            "symbol": "x"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "MethodDecl",
+            "retType": "void",
+            "name": "g",
+            "params": [
+                {
+                    "kind": "ArgDecl",
+                    "type": "int",
+                    "name": "x"
+                }
+            ],
+            "body": {
+                "kind": "Block",
+                "statements": [
+                    {
+                        "kind": "Assign",
+                        "id": {
+                            "kind": "Access",
+                            "a": {
+                                "kind": "Var",
+                                "symbol": "a"
+                            },
+                            "b": {
+                                "kind": "Var",
+                                "symbol": "x"
+                            }
+                        },
+                        "expr": {
+                            "kind": "Var",
+                            "symbol": "x"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "MethodDecl",
+            "retType": "void",
+            "name": "h",
+            "params": [],
+            "body": {
+                "kind": "Block",
+                "statements": []
+            }
+        },
+        {
+            "kind": "Call",
+            "id": "f",
+            "args": [
+                {
+                    "kind": "IntVal",
+                    "value": "10"
+                }
+            ]
+        },
+        {
+            "kind": "Call",
+            "id": "g",
+            "args": [
+                {
+                    "kind": "IntVal",
+                    "value": "20"
+                }
+            ]
+        },
+        {
+            "kind": "Call",
+            "id": "h",
+            "args": []
+        },
+        {
+            "kind": "Var",
+            "symbol": "a"
+        }
+    ]
+}

--- a/translator/src/main/scala/com/github/gchudnov/bscript/translator/internal/ScalaVisitor.scala
+++ b/translator/src/main/scala/com/github/gchudnov/bscript/translator/internal/ScalaVisitor.scala
@@ -349,7 +349,6 @@ private[translator] final class ScalaVisitor(laws: TranslateLaws) extends TreeVi
     yield ss.withLines(lines)
 
   override def visit(s: ScalaState, n: Call): Either[Throwable, ScalaState] =
-    println(("n.args", n.args))
     for
       as <- n.args.foldLeft(Right(s.withLines(Seq.empty[String])): Either[Throwable, ScalaState]) { case (acc, e) =>
               acc match

--- a/translator/src/test/scala/com/github/gchudnov/bscript/translator/internal/ScalaVisitorSpec.scala
+++ b/translator/src/test/scala/com/github/gchudnov/bscript/translator/internal/ScalaVisitorSpec.scala
@@ -754,7 +754,6 @@ final class ScalaVisitorSpec extends TestSpec:
 
             actual.contains(expected) mustBe true
           case Left(t) =>
-            println(t)
             fail("Should be 'right", t)
       }
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-ThisBuild / version                := "1.3.4-SNAPSHOT"
+ThisBuild / version                := "1.3.5-SNAPSHOT"
 ThisBuild / versionScheme          := Some("early-semver")
 ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible


### PR DESCRIPTION
closes #3 and #4 

## Description

- when method has no annotations it was not possible to deserialize it from AST. This PR addresses this issue, making it possible.
  - update tests
- update readme with an example of usage.
